### PR TITLE
Fix MEETING_DETAILS storage and Pipecat WebSocket port

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -205,15 +205,13 @@ async def join_meeting(request: BotRequest, client_request: Request):
 
 
     # Store all relevant details in MEETING_DETAILS dictionary
-    MEETING_DETAILS[bot_client_id] = {
-        "meeting_url": request.meeting_url,
-        "persona_name": resolved_persona_data.get("name", persona_name_for_logging), # Use display name from resolved data
-        "meetingbaas_bot_id": None,  # Will be set after creation
-        "enable_tools": request.enable_tools,
-        "streaming_audio_frequency": streaming_audio_frequency,
-        "final_prompt": final_prompt, # This is the prompt with interaction instructions
-        "persona_data": resolved_persona_data # Store the resolved persona data
-    }
+    MEETING_DETAILS[bot_client_id] = (
+        request.meeting_url,
+        resolved_persona_data.get("name", persona_name_for_logging),  # Use display name from resolved data
+        None,  # meetingbaas_bot_id, will be set after creation
+        request.enable_tools,
+        streaming_audio_frequency
+    )
 
     # Get image URL: Prioritize request.bot_image > persona_data.image > generate_image (if custom prompt and details derived)
     bot_image = request.bot_image
@@ -297,7 +295,10 @@ async def join_meeting(request: BotRequest, client_request: Request):
 
     if meetingbaas_bot_id:
         # Update the meetingbaas_bot_id in MEETING_DETAILS
-        MEETING_DETAILS[bot_client_id]["meetingbaas_bot_id"] = meetingbaas_bot_id
+        # Convert tuple to list to allow assignment
+        details = list(MEETING_DETAILS[bot_client_id])
+        details[2] = meetingbaas_bot_id
+        MEETING_DETAILS[bot_client_id] = tuple(details)
 
         # Log the client_id for internal reference
         logger.info(f"Bot created with MeetingBaas bot_id: {meetingbaas_bot_id}")

--- a/app/websockets.py
+++ b/app/websockets.py
@@ -50,7 +50,7 @@ async def websocket_endpoint(websocket: WebSocket, client_id: str):
             logger.info(f"Pipecat process already running for client {client_id}")
         else:
             # Start Pipecat process if not already running
-            pipecat_websocket_url = f"ws://localhost:8766/pipecat/{client_id}"
+            pipecat_websocket_url = f"ws://localhost:7014/pipecat/{client_id}"
             process = start_pipecat_process(
                 client_id=client_id,
                 websocket_url=pipecat_websocket_url,
@@ -80,7 +80,7 @@ async def websocket_endpoint(websocket: WebSocket, client_id: str):
     except WebSocketDisconnect:
         logger.info(f"WebSocket disconnected for client {client_id}")
     except Exception as e:
-        logger.error(f"Error in WebSocket connection: {e}")
+        logger.error(f"Error in WebSocket connection: {e} (repr: {repr(e)})")
     finally:
         # Clean up
         if client_id in PIPECAT_PROCESSES:


### PR DESCRIPTION
- Store MEETING_DETAILS as a tuple (not dict) to match websocket handler expectations and prevent KeyError.
  - Update meetingbaas_bot_id in MEETING_DETAILS by converting tuple to list and back.
    - Change Pipecat WebSocket URL to use port 7014 (not 8766) so subprocess connects to the correct API server port.
      - Improve WebSocket exception logging to include repr(e) for better debugging.